### PR TITLE
Tutorial notebook demonstrating functionality implemented in MuPT-hub/mupt#22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,6 @@ cython_debug/
 # Notebook outputs
 **/alignments/*
 **/OpenFF_MD_input_files/*
+**/examples_*/*.pdb
 *.mol
 *.sdf

--- a/examples_system/Random_CoPolymer_Quickstart.ipynb
+++ b/examples_system/Random_CoPolymer_Quickstart.ipynb
@@ -1,0 +1,1192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9a78ec22",
+   "metadata": {},
+   "source": [
+    "# Random CoPolymer Tutorial: From SMILES to MD Simulation\n",
+    "\n",
+    "This notebook demonstrates a complete molecular simulation workflow using the **Multiscale Polymer Toolkit (MuPT)**. Starting from SMILES strings defining polymer repeat units, we build a random copolymer system with a `AngleConstrainedRandomWalk` to generate initial coordinates, then export it to multiple molecular modeling formats. The workflow covers the entire pipeline from chemical definition to running molecular dynamics.\n",
+    "\n",
+    "The tutorial showcases MuPT's key capability: **separating molecular representation from chemistry and geometry**. We define polymer chemistry with SMILES, build hierarchical Primitive objects with embedded shapes, then export to MDAnalysis (for analysis), RDKit (for chemical manipulation), and OpenFF (for force field parameterization). Finally, we run an NPT simulation with OpenMM, demonstrating a complete path from polymer specification to production-ready MD.\n",
+    "\n",
+    "NOTE: If you are testing the MD simulation via OpenMM, make sure you have access to a GPU. We want CUDA to show up and run when you run the following command: `python -m openmm.testInstallation` in the terminal. You should see something like: \n",
+    "\n",
+    ">OpenMM Version: 8.4\n",
+    ">Git Revision: 47684368dbbe4185d068be77d32a962059cfc37c\n",
+    ">\n",
+    ">There are 3 Platforms available:\n",
+    ">\n",
+    ">1 Reference - Successfully computed forces\n",
+    ">2 CPU - Successfully computed forces\n",
+    ">3 CUDA - Successfully computed forces\n",
+    ">\n",
+    ">Median difference in forces between platforms:\n",
+    ">\n",
+    ">Reference vs. CPU: 6.28082e-06\n",
+    ">Reference vs. CUDA: 6.74689e-06\n",
+    ">CPU vs. CUDA: 7.61024e-07\n",
+    ">\n",
+    ">All differences are within tolerance.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35366239",
+   "metadata": {},
+   "source": [
+    "## 1. Setup and Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "144fff02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# MuPT building utilities\n",
+    "from mupt.builders.copolymer import (\n",
+    "    build_copolymer_system,\n",
+    ")\n",
+    "\n",
+    "# MuPT export interfaces\n",
+    "from mupt.interfaces.rdkit.exporters import primitive_to_rdkit_hierarchical\n",
+    "from mupt.interfaces.mdanalysis.exporters import primitive_to_mdanalysis\n",
+    "from mupt.interfaces.openff import (\n",
+    "    primitive_to_openff_molecules,\n",
+    "    save_openff_system,\n",
+    "    load_openff_system,\n",
+    ")\n",
+    "\n",
+    "# Visualization\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d23fe5ed",
+   "metadata": {},
+   "source": [
+    "## 2. Define Polymer System\n",
+    "\n",
+    "Specify the chemistry and composition of your copolymer system:\n",
+    "- **SMILES** for each repeat unit type (head, middle monomers, tail)\n",
+    "- **Monomer distribution** for the middle units\n",
+    "- **System parameters** (chain count, lengths, etc.)\n",
+    "\n",
+    "### SMILES Conventions\n",
+    "- Atom map number `[*:1]` marks the **head** connection site (ANTERO direction)\n",
+    "- Atom map number `[*:2]` marks the **tail** connection site (RETRO direction)\n",
+    "- Use `*` for linker atoms that will be removed during chain connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "86e10578",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "System: 10 chains with 5-20 monomers each\n",
+      "Composition: {'bisphenol_S': 0.4, 'bisphenol_A': 0.6}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define repeat unit chemistry\n",
+    "# This example creates a PSU/PES copolymer (polysulfone/polyethersulfone)\n",
+    "rep_unit_smiles: dict[str, str] = {\n",
+    "    'head': '[H]-[O:1]c1ccc(cc1)S(=O)(=O)c1cc[c:2](cc1)-*',\n",
+    "    'bisphenol_S': '*-[O:1]c1ccc(cc1)S(=O)(=O)c1cc[c:2](cc1)-*',\n",
+    "    'bisphenol_A': '*-[O:1]c1ccc(cc1)C(-C)(-C)c1cc[c:2](cc1)-*',\n",
+    "    'tail': '*-[O:1]c1ccc(cc1)S(=O)(=O)c1ccc(cc1)[O:2]-[H]',\n",
+    "}\n",
+    "\n",
+    "# Define middle monomer distribution (must sum to 1.0)\n",
+    "rep_unit_distrib_mid: dict[str, float] = {\n",
+    "    'bisphenol_S': 0.4,  # 40% PES units\n",
+    "    'bisphenol_A': 0.6,  # 60% PSU units\n",
+    "}\n",
+    "\n",
+    "# System parameters\n",
+    "n_chains: int = 10           # Number of polymer chains\n",
+    "chain_len_min: int = 5       # Minimum chain length (repeat units)\n",
+    "chain_len_max: int = 20      # Maximum chain length\n",
+    "\n",
+    "# Placement parameters\n",
+    "R_excl: float = 20.0         # Starting radius from origin\n",
+    "bond_length: float = 1.5     # Distance between repeat unit centers\n",
+    "angle_max_rad: float = np.pi / 4  # Maximum bend angle\n",
+    "\n",
+    "print(f\"System: {n_chains} chains with {chain_len_min}-{chain_len_max} monomers each\")\n",
+    "print(f\"Composition: {rep_unit_distrib_mid}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadd8dfc",
+   "metadata": {},
+   "source": [
+    "## 3. Build the Polymer System\n",
+    "\n",
+    "The `build_copolymer_system` function:\n",
+    "1. Parses SMILES into oriented Primitive objects (with ellipsoidal shapes)\n",
+    "2. Generates random chain sequences from the monomer distribution\n",
+    "3. Places chains using an angle-constrained random walk (NOTE: This will eventually be replaced by the DPD initializer)\n",
+    "4. Returns a universe Primitive with hierarchy: `universe → chains → residues → atoms`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d4bc0a8e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b15b7d7953a04e10a681d5afe2c06db5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attempting to infer internal connections automatically from given topology; user should verify the connections \n",
+       "assigned make sense!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "universe\n",
+      "├── 11-mer_chain\n",
+      "├── 8-mer_chain\n",
+      "├── 17-mer_chain\n",
+      "├── 19-mer_chain\n",
+      "├── 15-mer_chain\n",
+      "├── 12-mer_chain\n",
+      "├── 17-mer_chain\n",
+      "├── 9-mer_chain\n",
+      "├── 11-mer_chain\n",
+      "└── 14-mer_chain\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the polymer system\n",
+    "univprim = build_copolymer_system(\n",
+    "    rep_unit_smiles=rep_unit_smiles,\n",
+    "    mid_distrib=rep_unit_distrib_mid,\n",
+    "    n_chains=n_chains,\n",
+    "    chain_len_min=chain_len_min,\n",
+    "    chain_len_max=chain_len_max,\n",
+    "    bond_length=bond_length,\n",
+    "    angle_max_rad=angle_max_rad,\n",
+    "    exclusion_radius=R_excl,\n",
+    "    random_seed=42,  # For reproducibility\n",
+    ")\n",
+    "\n",
+    "# Display hierarchy summary\n",
+    "print(univprim.hierarchy_summary(to_depth=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "73800c7b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApQAAAHzCAYAAACe1o1DAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAT1VJREFUeJzt3Qd41FW+//FvGokJTbpKUykiRa8uCioKq2BHwIuoIPbuWnbVi7iKsv5RdFexr3W9Koqii2JHXFR0FVnXq4gFECGIAhKkJbSU//M57C/OTMpMcmaSSfJ+PU8edMpvJjNncj6/7ymTUlJSUmIAAABANaVW944AAAAAgRIAAADeqFACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAv6X53B1Ab8rcV2rK8fNteWGyN0lOtc8scy8nk44y6ifYM1H30QEAdsXj1Jps6L9fmfLvGctcVWEnIdSlm1rFFtg3q3sZGH9zRurZtUovPFIiO9gzULyklJSWh/RKAJLNiXYGNn7HA5i5Za2mpKVZUXPFHNrh+QJdWNml4b+vQIrtGnysQDe0ZqJ8IlEASmzY/1ybMXGiFxSWVBsnygmV6aordPLSnndq3Y0KfIxAr2jNQfxEogSR135zF9udZi7yPc/WQbnbZoK5xeU5AddGegfqNVd5AklZy4hEmRcd5bn5uXI4FVAftGaj/CJRIKhMnTrR9993XiouLSy9LSUmxJ554ovT/N23aZNdee60NGTLEWrdu7a6/6aabyj2epgjfc889ts8++1hmZqbttttudvHFF9svv/xiyTzHTMPc8XTjzIX2/Mw33Wv1wgsvxO24el90zGXLllX5vrqP7vvuu+9W+/Fnz55t/fv3t+zsbGvVqpWdddZZtmbNmrDbvPPOO9a4cWNbuXKl1fX2rOsq+lEbT0a05/rTnoHKECiRNH788Ue7/fbbXSecmlpx08zLy7OHH37Ytm3bZsOGDav0mFdffbVdddVVdtJJJ9mrr75q48aNs2eeecYGDx5sO3bssGSkBTiaMxlPOt4jc5davB1//PH20UcfuaBe09577z079thjrW3btvbyyy/b3Xff7TrkI4880rWNgP7/oIMOsvHjx9f59qzXOvJnypQp7rrhw4dbMqI914/2DETDtkFIGvoD2rx5cxsxYkSlt+vUqZOrMKoqs3btWnv00UfLvZ3O4HXMSy+91CZPnuwuU5Bs06aNnX766a5KdP7551uybaWi1dyB4h1bLTUjy/u4WtCzYOUGizdV1PRTG6655hrr1q2bq7imp+/8U7bnnnvaoYceao8//rirRAfUBkaNGmW33HKLdejQoU62Z+nXr1+Zyx566CF333PPPdeSDe25/rRnIBoqlEgK27dvt8cee8wFvcqqORIM8UXz8ccfW1FRkR133HFhl59wwgnu3xdffDHmYdk77rjDhdLOnTvbLrvsYgMHDrRFixa5Kqeqnrvvvrs1a9bMVYkih6jkueeec0NZOTk5brjq6KOPts8++yzsNhre6tm5rRWtXW6rp91guXeOtNXPXm+xKty01vLeuNd+uP8sW377MPvhvrH284xJVpS/c3g/NXXna6bnfP3117vn3LRpUzvqqKPs22+/DTvW22+/7aq67du3t6ysLOvSpYtdeOGFLvBEG/LWa9OrVy+bP3++DRgwwA3f7bXXXnbbbbeFDf360MmCjn/GGWeUdr5yyCGHuE55xowZYbc/8cQT3ev+yCOPWF1tz+XRcPn06dPtiCOOcO9RNLRn2jOQKARKJIV58+a5ob9BgwaVOw9SYas6nbpo7mSojIwM14F/8cUXMR/r/vvvtw8//ND9qwrSN99840KKqkI///yzqyBoeFNDVOedd17YfSdNmmSnnXaam0v3/PPP21NPPeWCgMLWV199FXbbwh077KfpEy2rUx9rPeKP1nzA6JjD5Kr//b0VLPrImvYdZm1Oucl2PfJ8S8nMseKtm91tiv8zjK6hsuXLl7vfQ0Otixcvdr+Lwnfgu+++cwH4wQcftFmzZtmNN97o3qPDDjsspqkCq1atstGjR9uYMWNs5syZbijvuuuus6effrr0Ngrnem8VQKvqyy+/dP/26dOnzHW6LLg+0KhRIxc2X3vtNaur7bk806ZNs/z8/DJtLhraM+0ZiDeGvJEUNBdMDjjggLgdUwFOFARDO/Z//vOfrlNXhx8rDV2+9NJLpdUmVequvPJKtxBC850CCpqa07Zx40ZX/VuxYoVNmDDBLrvsMrc4KKCh965du9rNN9/sqpeyo6jYSooKrfmhp1rjPoOr9LuunzvVigo22u7n3GsZrX4dAsvpMaDMbbvv0yMs2KWlpdkpp5ziKn7BkOpFF11Uer1eK4UxBT8Nz77xxhs2dOjQSp+PXtvXX3/dzfUSVUG1+EbzV8eOHVul362i40uLFi3KXKfLyntv1bZuvfVWF8BUKa5r7bk8qoKqbZ588slVuh/tmfYMxBsVSiQFLWBQ1VArG+Nlv/32s8MPP9wNV2tYcP369S5MKiwpRIUORao6V1hYWPoTOTSrYfPQ2/fo0aN0UUqo4PLc3J3b9Lz11lvueApRocfXMLKGKUNXOOv7jCW7+6FV/l23Lv3Usjr1DguTFTl44JCw/w+qfKpaBjRsr9dJ87M0pKyqrsKkfP3111Efo127dqVhMvRxQh8jHioaKi7vcs2d1fuq6mldbM+RFi5c6CqhqgSrPYWiPdOegZpGhRJJYcuWLS60KOjFk4KkhhdVgQuGPrXqW0PTCpiBvffeOyzsqKoYunVLZCVMx6ns8q1bt7p/V69e7f7t27dvuc8vNKRqRDolI9NSM6v+dYlFBRssq0ls4aVx0+Zh/x9MCdB74J5HcbHbwkah6IYbbrDevXu7ip4uVwUzuF1lWrZsWeYyPU4s941FcPzyKpHr1q0rt3IZhK54PYfaaM+R1Ukpb7ib9kx7BmoagRJJQZUczXmM93CkqlIaelXFTZUpVdm0qOaBBx6w//7v/y693SuvvBK2NYcWrMRDUKHSys2gwleRnWtmqrc4Iy27mRVtCl8wU5H0tMoHJjT/8PPPP3cLbs4888zSy5csWWLJQot+ZMGCBWUWXemy4PrIoCmJrBomuj0HdGzNxT3wwANt//33L3M97flXtGegZhAokRSCTZm1GKS8hRbxCJb6Ec1lVEeveY0BVeESQau5NWSs3yvaPLfGmdX/OGbtdaDlfznHduT9YBkt21d629ZNwhcpVTRcHLmYSdvTJIs99tjDDalrLqj2Gg0qgVrZrxXrmt8aaenSpa6yqX3+6np71kInzePVHpfloT3/ivYM1AwCJZJCsNJXgSCWDlgLQxQKtVpatFo6+AYYVay0VY0E28RoCFBD3Lqfhgq18jrRCyaClczq9LVNjwLNMcccY7vuuqsbCv/kk09c9UoLc4LKYTV3j3GrwTWPctXUcdas/0jLaN3ZSrbl25aln1rTg4ZZRstf51ZmZaRFDUN6vbQdkhbkaPhYFS9tJZRo2tZGe++pMhr6bTLl0TZOWtw0cuRIu+SSS1wVWs9Z1cmzzz67zO3VtjRvtbpb9CRDew6oDavSrm2JahLtuWG2ZyAWBEokBS3+0DY6WjF9wQUXRL29NvkNnfOouZL6ke+//951fKJApFXXuq3mK/7Xf/2X26NQeyzWFG2XoxXn2uj62WefdUPrWrSieZWhq6klLTXF/Wgj8qpIb9LK2o2909Z/MNU2fvyCFW3ZZGnZTS2zfU9LzWoStg9lNJr7pwB5xRVXuL0nVWHVKm3NO+3YsaMl0ubNO7c4iuWbdxTaNJ1BWxpp2yOFLu0xqkVYkdVVVQo1FF7RVxrWlfYs2jlAWzlpSybtfVrTaM8Nrz0DsUgpUY8LJAFtNK5vf1DHqiHNhkjfLDJ4yvsJO/7sqw63Lm12BsxkpLmt+l5rdZjxHJrW4qInn3zSHTd0I/REoj3TnutTewaiYdsgJA19RZ2qdtorsKHq2raJDejSylUp40nH03GTOUzKnDlz7PLLL49r56upDtrIW9McarLzpT3TnutTewaioUKJpKIVmVpwoLlD0b6yrr5asa7AjrrrPdtWWOyG7K0kytcVpmjuZeUBNDM91WZfdYR1aFH1LYnqOn3FpYbrtXinpueb0Z5pz/WpPQOVIVACSWja/Fwb9/cFtvmL2Zb3+pRKb9v2tEnuqxorM3lEbxvVN7HzH4GK0J6B+o9ACSSp++Ystskv/8sK1+/cHL0iGS32qHQz9GuGdLdLB3VJwDMEYkd7Buo3AiWQ5JWdCTMXWmFxSZVWfmvOZHpqik0c2pPKJJIG7RmovwiUQB2YUzl+xgKbu2Rt1C2Fguu1AGfS8N4Ncs4kkhvtGaifCJRAHdpSaOq8XJuzaI3l5hVYaKzU1PyOLbNtULc2NqZfx6RfzQ3QnoH6hUAJ1EH52wptWV6+bS8stkbpqda5ZY7leHx1I1CbaM9A3UegBAAAgJeGudEfAAAA4oZACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAACJQAAACoPVQoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwku53d1RH/rZCW5aXb9sLi61Reqp1bpljOZm8FQAA0K/WTaSYGrJ49SabOi/X5ny7xnLXFVhJyHUpZtaxRbYN6t7GRh/c0bq2bVJTTwsAgDqJfjW5pJSUlIRmG8TZinUFNn7GApu7ZK2lpaZYUXHFL3dw/YAurWzS8N7WoUU27wcAAPSrSY9AmUDT5ufahJkLrbC4pNIgWV6wTE9NsZuH9rRT+3ZM5FMEAKDOoF9NXgTKBLlvzmL786xF3se5ekg3u2xQ17g8JwAA6ir61eTGKu8EnUHFI0yKjvPc/Ny4HAsAgLqIfrWBBcqJEyfavvvua8XFxaWXpaSk2BNPPFH6/5s2bbJrr73WhgwZYq1bt3bX33TTTeUe76yzznLXR/7ss88+lsxzJjXMHU83zlxoz8980/3uL7zwQtyOq/dFx1y2bFmV76v76L7vvvtutR9/9uzZ1r9/f8vOzrZWrVq593vNmjVht3nnnXescePGtnLlymo/DgDUN7H0t/LZZ5/ZsGHDbPfdd3d/a9V/6r4FBQVWV8SrX/3hgXNszfSbS/tVHddXZRkmmoEDB7p+r7rUX+r+6j/13qo/VZ8ZaseOHbb33nvblClTrM4Eyh9//NFuv/1211BTUys+bF5enj388MO2bds218ij2WWXXeyjjz4K+3nuuecsWWkBjuZMxpOO98jcpRZvxx9/vHs9d9ttN6tp7733nh177LHWtm1be/nll+3uu+92AfPII490bSOg/z/ooINs/PjxNf4cASAZxdrffvXVV3bIIYe4AoACxauvvmqnnnqqu99pp51mdUWi+lUd15f60PPOO89qmvpJ9Y8KkOo/1Y+qPz3mmGNc/xrIyMiwG2+80b3nyl91Ytsg/ULNmze3ESNGVHq7Tp062S+//OJS/dq1a+3RRx+t9Pb6sPTr18/qyhYGWs0dKN6x1VIzsryPqwU9C1ZusHhThVg/teGaa66xbt26uYprevrOZrjnnnvaoYceao8//rhdfPHFpbe99NJLbdSoUXbLLbdYhw4dauX5AkCyiLW/feaZZ2zr1q324osvuiqV/Pa3v7WffvrJFXbUF++6666WrFRdW7Jmc1i/Gi/qV3XcJWs2WZc21d+qr7byyWOPPWZffvml/fOf/3SVSRk0aJDtt99+bhR43rx5pbfVycPvf/97e+ihhxJanIlLhXL79u3ulzv99NMrPVuSYNi6JgTDsnfccYdNnjzZOnfu7CqeKjMvWrTINdZx48a5oYBmzZrZ8OHDywy5iiqiesNycnLc8OvRRx/thhFCqezcs3NbK1q73FZPu8Fy7xxpq5+9PubnWrhpreW9ca/9cP9Ztvz2YfbDfWPt5xmTrCj/F3d9aurO10zP+frrr3fPuWnTpnbUUUfZt99+G3ast99+20466SRr3769ZWVlWZcuXezCCy90AT7akLdem169etn8+fNtwIABroy+11572W233RY2tOJDw9c6/hlnnFEaJkVn0gqZM2bMCLv9iSee6F73Rx55JC6PDwB1VVX6W1WnRP1bKIVR3bdRo0ZRHy/oE1SJ099o9aHqS//2t7+561977TU74IADXF/Ru3dve/PNN8scY/Hixe75tmnTxjIzM61Hjx52//33h91G06fUHz311FP2hz/8wfbYYw932/tf/sDtfBJNSUmxbfzXK/bj47+z3D+PsNy7RtlPT/7BChb/GqwCW5Z+aj/97Qp3u34H7OeKGKF+/vlnu+SSS9yUAvU9et4K4nPnzo065P3Ef/rVOXPmuMKIhqNbtmzpwr8qy/GifrJ79+6lYVLUn44ZM8Y++eSTsGliep9VlNFJRCJ3ioxLoFQSVilV6TiSnrzPHIEtW7ZYu3btLC0tzQWkyy67zNatW1elY6jhfvjhh+5fVUS/+eYbF1LOPfdc13DUmDR8oCHXyNL1pEmTXLpXw3r++eddY9c8UIUtDSeEKtyxw36aPtGyOvWx1iP+aM0HjI45TK76399bwaKPrGnfYdbmlJts1yPPt5TMHCveutndpvg/5X6dXSxfvtz9Hmoc+qDqdykqKio93nfffeca2YMPPmizZs1y5W69R4cddpgLpNGsWrXKRo8e7RrmzJkz3dD0ddddZ08//XTpbfQHRe+t/thUlc6qpE+fPmWu02XB9aEfBv0h0x8uAGjIqtLfnnnmmS48KtgsXbrU9V0a9lalSiM/KpLEQn3C2Wef7fpHDa0qOJ5zzjluGFV9gypiqoIqfGkqW2hwUj/Zt29f93f9L3/5i3t8Tbe6/PLL7eabd85nDKXj5ebm2l//+ld75ZVX7N8/F8e07V7eq3fZL7Mftszdulqrk/7HWp90rWV3OdgKN6wOu932Nd/bL/94zJr0Pclan/xHS2nZ0WWB999/v/Q2QcaYMGGC63cUnlVYUX8X67qB8847zwV6VYmVL3Q/9amhdFnknNdY6fWsqA+VhQvD55zquSs7RPavSTfkrTMX0VlKPKl0qx+dHYnmBdx1111uzoAqXGq8sdAH6qWXXio9m1Ol7sorr3STk/XhCChoap7Jxo0bXfVvxYoVrkEpxN5zzz2ltxs8eLB17drVfRiC+Zw7ioqtpKjQmh96qjXuM7hKv+f6uVOtqGCj7X7OvZbR6tch3ZweA8rctvs+PcKCnYL2Kaec4l6PoPR+0UUXhf2BURhTY9J0gzfeeMOGDh1a6fPRH6vXX3/dzV0UVUHV8PXBGDt2bJV+t4qOLy1atChznS4rb56H2tatt95q+fn5Mf8RBID6pir9rU78dXuNvgVD3qIwV5VFGvqb/NZbb9mBBx7o/v83v/mNq9pp5GrJkiVuxEz07/777+/C5e9+9zt3mYZamzRpYh988IHrV4M+VHMAdX89l9Bhdz3P6dOnu//evK3QLvvgrajPb+uKLy1/4Rxresgo2/XwM0ov32Wvnc83VPGWjdZuzO2W3qyN+/+SDr2sxQ8LXP92+OGHu8tU+XvggQdK76OCjUYmNZqnLBBLIeWYY44Jyw0KqQreCucqkvnSe1JRHxpcHypoLyqu6YQgaSuUOhtRiVel3Xi66qqr3I8an340h+7JJ590wS90+FNvdmFhYelP5NDscccdFzY0oHK76CwpVHC5zo5EHyAdTyEq9PgaRj7iiCPCzlT0/dyS3f3QKv+eW5d+almdeoeFyYocPHBIuWcjOvMIaNheoVLzDVUC11mSwqR8/fXXUR9DjT0Ik6GPE/oY8VDR1IfyLtcfL72v+jACQENVlf5WAUgjWBpy1Xx1FWVULVNVLHQ0Tn9bQ/u40BEv0cLNIEwGoUV/kxUegzAZ2ocGfYXmb6oApECrIfHQx1C/rOs//vjjsMc6+eSTS/97eV5+2NcUV0RD2NLkgPA+vTwZbfYsDZOSkt7IOnTeu0z/pgqpQpj6+6Af1e8SSx8qkYWb8vpqX5VNH4y8Tu+XJHLHlLhUKDUsrRdb1bJEU8NUhSq0EeqMJvRNUlUxdE5DZIoP5o1UdLkauaxevbNUrnJ9eUJDqiryKRmZlppZ9a9LLCrYYFlNYgvjjZs2D/t/zTEJ3gP3PIqL3ZZM+qNzww03uDMRvV66XBXM4HaV0R+fSHqcWO4bi+D45VUidRZX3lmXPtQSr+cAAHVRVfpbrRHQiNv//d//lY7sqAqnMKohaxVLVBzR0HXo8LMKEKFz68v7m6z+Mlofqr/xCo/33nuv+ylP5Nz+0F1HthfGNm+/uGCDWUqqpeVEX2CUtsvOKmmo9EaNwvqWO++8083jVGHmT3/6k3u99HqrT401ULaM6Ecj+2pfOn5FfahEvjc10YfGJVDqxdZE4ZoajtQwbmiY0zyL0K1mQs+YfARngDqzCyp8Fdk5Z7h6i43SsptZ0abYVrGlp1VeVNb8iM8//9ydgWr+TEDDEskimMKwYMECd5YaSpcF15f3IYl3FRwA6pKq9LcKkpr/H3m7oEii/kKB8oILLrATTjihTPjxpaFsBTEtwNSczfJod4+KKmuN0mMbRE3NbmZWUuwWsaY3Lht+o4ks9GlamYa1tQ4hlOagJovevXu7/jJScFlkP1oTfWhcAmWw0bgWg5Q3STSeFO60IWvoUv1EzQfQnAmVuvV7hZbhy9M4s/ovZdZeB1r+l3NsR94PltGyfaW3bd2k8g968GGM/IOgSdjJQqv3NKSuD+3VV19deqatqrNWrGt+ayRNKNcZmfbZAoCGqir9rYorCo2bN28OW3MQzMPUQtfgdvEqxITSMLcWD2lXFD3XWFaVh+rcMseVaaINe2uu5MaPptvmf79uzQ8PX/gSjY6flZ5Wph+N7EO/+OIL97oly9Z1w4cPdyvRtUjr4IMPdpepGqx+Vf8f+X6qDxWdYCR1oAwmqCoQxBIotTBEZ1dB2tcqsOAbYFSxUiPUELa2GdAmrNr2Rm+w5n9oInHPnj1rZCNRTWjWUIC26dGboUm2OuPSULiW5eusLxgmUOWwurshaTW45lGumjrOmvUfaRmtO1vJtnw3L6TpQcMso+WvDTgrIy3qHxtNAdBQhyq5KnurgquthBJNQyQ621RlNNrKNW3jpHmxI0eOdB8KzfvUc9ZZlVYTRlLb0pl0TW05BQDJqCr9rU7Otepaf2u1HkHVKd1PCxwVLLSDR03smakdRrQzilabq19V369RM/VN//jHPyq8b05munVskW3Lo3yjTVaHXpbTc5Bt+OdzVlSw3nbZu6+lpGfY9tVLLSU905r+5sQK79uxZbalRGxLpGqthro1fU79jgodygLq3xTaEv3+vvfee1G399GUBe1coz5Ui5s0R1ILifRctWNNJL3vKt4EC4+SNlAqsauxaMW0SufRqFGFznnUiq5gVdf333/vGpxWg6kapbkMCnCaJKxhZ60I09Y5NbXSV1sY6IOnD8Wzzz7rhta1aEVDBqGrqUV7Zeknli0OQqU3aWXtxt5p6z+Yahs/fsGKtmyytOymltm+p6VmNQnbhzIaza3Rh/SKK65we0+qwqpV2mpgHTt2tETSWbDE8s07+tBoJbm2NNKkcZ1E6EOsPUMjzwx1Jq4yfnW/3goA6ouq9LdaGKKFJAoc6hM2bNjg7q++QX1bVSuG1aH+89///rcLaH/84x9d8UA7r2inlMgpT+UZ1L2NPTVvedR+teUJV1mjdl1s8xezbPOC2S5INmrVwZr2P6XC+6i/HtStjUVuBKQikkZCtd+nFjHpd9AiHe396PN1w7H2o7GsAlc/qfdWK8e1ol7PV4ukVLBTCI6knW70euu1T5SUkjjtcqltArRxpoKihjQbIn1TzuApv+5lFW+zrzrca0f/RNPZkRq3AmA8h6Y1EVqr+3Xc0I3QAaAhakj9bUPqVzdt2uRGFTUSW9Gc0+pQ36kAr51rVK1O+u/y1i7wqtqplN5QdW3bxAZ0aRXTrv5VoePpuMnS6CuibwZQBTmeYXL9+vWurK8N5gmTANCw+tuG1K++//777gTh/PPPj+txteWivvc7kWEyroFSc9u0N6QmgsbrK/rqoknDe1v6fxq+ir8lxUWV/8RQINbxdNxkp2kLCn7xpCkQGprRfFoAQMPqbzVnceKJPSzNiivoQ6v3+ydjv3r88ce7tQjxnIqg10/rKiK/6jKph7zxq2nzc23c3xfY5i9mW97rlX8bQdvTJrmvaqzM5BG9bVTfxM5/BAAg2URbiJnT60hrdcJVVT4u/Wr8MSEtAU7t29HWbt5mk/UVT2feVeltM1pUPv/lmiHdCZMAgAZJXysceP5fufbUxzu/ya6yjcqjoV9NDCqUCa5UTpi50AqLS6q08ltzO1SOnzi0J2ESAAD61aRHoEywFesKbPyMBTZ3ydqoWwoF12uisOZ2dGhR9a9xBACgPqNfTU4Eyhrc+mDqvFybs2iN5eYVhO38n/KfzVW1H9aYfh2TatUZAADJiH41uRAoa0H+tkJblpfvvvhe31Wqr5fSNwIAAAD61bqIQAkAAIDk2IcSAAAADROBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPBCoAQAAIAXAiUAAAC8ECgBAADghUAJAAAALwRKAAAAeCFQAgAAwAuBEgAAAF4IlAAAAPCSbkkof1uhLcvLt+2FxdYoPdU6t8yxnMykfKoAAADW0HNR0jybxas32dR5uTbn2zWWu67ASkKuSzGzji2ybVD3Njb64I7WtW2TWnymAAAAibW4juWilJKSktDnWONWrCuw8TMW2Nwlay0tNcWKiit+OsH1A7q0sknDe1uHFtk1+lwBAAASaUUdzUW1Giinzc+1CTMXWmFxSaUvWHkvYHpqit08tKed2rdjQp8jAABATZhWh3NRrQXK++Ystj/PWuR9nKuHdLPLBnWNy3MCAACoDffV8VyUWlsJPB4vmug4z83PjcuxAAAAatq0epCLUmtjboDKufF048yF9vzMNy0lJcVeeOGFuB33iSeecMdctmxZle+r++i+7777brUff/bs2da/f3/Lzs62Vq1a2VlnnWVr1qwJu80777xjjRs3tpUrV1b7cQAAqA0TJ060fffd14qLi0svU9+p/jewadMmu/baa23IkCHWunVrd/1NN91U7vE++OADO++88+zAAw+0zMzMavfhNWlFHcpFSRUoNdFUcwPiScd7ZO5Si7fjjz/ePvroI9ttt92spr333nt27LHHWtu2be3ll1+2u+++2wXMI4880rZt21Z6O/3/QQcdZOPHj6/x5wgAQHX9+OOPdvvtt7tQmZpacRzJy8uzhx9+2PV9w4YNq/SYKrKor+zYsaMdcsghdeLNGV+HclHSBEotgdeqpWCiafGOrXE5ro63YOUGizedCfXr18+d5dS0a665xrp16+bOLAYPHmyjR4+2559/3r788kt7/PHHw2576aWX2tSpU23FihU1/jwBAKgOFUqaN29uI0aMqPR2nTp1sl9++cUVWm699dZKb3vDDTe4iuSMGTNcUSjZLa5juSgugbJZs2Y2fPjwMkOu8txzz7mh2ZycHDf8evTRR9tnn30WdhsN1/bs3NaK1i631dNusNw7R9rqZ6+P+YkWblpreW/caz/cf5Ytv32Y/XDfWPt5xiQryv9l5y+Sql2ZzHbs2GHXX3+97b777ta0aVM76qij7Ntvvw071ttvv20nnXSStW/f3rKysqxLly524YUX2tq1a6MOeQ8cONB69epl8+fPtwEDBrjh6L322stuu+22sJK9Dw1f6/hnnHGGpaf/ulWozrYUMvVBCXXiiSe61/2RRx6Jy+MDAJBI27dvt8cee8xOP/30SquTon5YP7GIdqxYp6vdcccdNnnyZOvcubPtsssuru9ftGiRyxjjxo1zGaMh5qLKxPzKqyytMrLmJoSaNGmSnXbaaW4OhCpoTz31lJvvoLD11Vdfhd22cMcO+2n6RMvq1Mdaj/ijNR8wOuYXbdX//t4KFn1kTfsOszan3GS7Hnm+pWTmWPHWze42xf9J9xr6Xb58uT366KOuRL548WIXuIqKikqP991337k3+sEHH7RZs2bZjTfeaPPmzbPDDjvMvfDRrFq1ylUMx4wZYzNnznRD09ddd509/fTTpbdRI9QCejXCqlIVUvr06VPmOl0WXB9o1KiRC5uvvfZalR8LAICapj5XQ9mDBg0qc536ToWt2nT//ffbhx9+6P5Vnvjmm29cljj33HPt559/diOFDSUXxf2bcpRU9YJOmTLFNm7c6FKuhlgnTJhgl112md1zzz2lt9UQbdeuXe3mm292KV12FBVbSVGhNT/0VGvcZ7BVxfq5U62oYKPtfs69ltGqQ+nlOT0GlLlt9316hAW7tLQ0O+WUU1zFT8PXctFFF4U1XIUxBT+V1d944w0bOnRopc9HH4LXX3/dzV0UpX0tvnnmmWds7NixVfrdKjq+tGjRosx1uiy4PtQBBxzghgLy8/PdGREAAMlK6xOCvisZaSj+pZdeKq14qlJ35ZVX2j777OPWNQQaQi6KVZVqwz169HD/5ubuXI7+1ltvWWFhoQtR+jf4Ubn0iCOOCFvhrO+hlOzuh1blIZ2tSz+1rE69w160ihw8cEjY/wdVPqXzgMrTevE6dOjghpQzMjJKX7Svv/466mO0a9euNEyGPk7oY8RDRSX+8i5v06aNG3JX9RQAgGRfkKO+TDuY1AZV50JzS+SUteOOOy5s+DzIP5HzMhtCLkrId3lraFW2bt05aXT16tXu3759+5Z7+9A3Q5XXlIxMS82s+tcCFRVssKwmsTW6xk2bh/1/sKBmy5YtO59HcbHbekCNWZN3e/fu7Sp6ulxJPbhdZVq2bFnmMj1OLPeNRXD88iqR69atK7dyqcYq8XoOAAAkivoqhRZVy2rD3nvvHRaoVFUM3Yoosp8N8k9Fl2+tx7koIYEyUnBmoZXI0ZLszrmhsU2qjZSW3cyKNsU2MTQ9rfKiq+Yffv75527BzZlnnll6+ZIlSyxZaNGPLFiwwJ0lhdJlwfWRQVNq62wPAIBYqa/Swpzamqb1yiuvhG3BpwUr8dCqAecir0CpVUsqjWoy58knn1zpbRtnVv+hsvY60PK/nGM78n6wjJbtK71t6yaVb/ETDBdHbgX00EMPWbLYY4893JC65jxcffXVpWdwH3/8sVuZpXkckZYuXeoqm9q3EgCAZKa5iKL8UN4C1ERTFS4Rjm7AucgrUGolszYk1XJ0BZpjjjnGdt11V1fy/eSTT9xZhyagugdKS7UYV/2XoVVPmi+wauo4a9Z/pGW07mwl2/Jty9JPrelBwyyj5a9zCLIy0qI2YpW6texfE09VvtaZipbMJ5q2I9hzzz3dGUDotwCUR9sVaBLvyJEj7ZJLLnHzG/ScVZ08++yzy9xeYVPzM2LdWgEAgNoS7ICiviuWQKkFs6pmarW0aLV08A0wGsnTFn6iFdjarzIY0Qvuq32l9aN+MpE6N+Bc5BUoRdvlaGm8Nih99tlnXQlZi1Y0fyB01ZCkpaa4n2ADz5ifZJNW1m7snbb+g6m28eMXrGjLJkvLbmqZ7XtaalaTsP2WotGcDb1QV1xxhVu5rjMJrdIOdtZPpM2bdy7lj+Wbd/Rh00pyLd3X8n59WE444QS3N1bkWYTOhPTBqeirqAAASCZa/KFtdLRi+oILLoh6+4svvjhszuP06dPdj3z//fcuyMnChQtdISaUijISuSgmUa5roLkopURxtAZ3hB885f2EHX/2VYdblzY7X8hk9MADD7jvI1UAjOfQtCbRPvnkk+64oRuhAwCQrF588UUbNWqUC4qa6tUQLa5HuahGv3qxa9smNqBLK5fG40nH03GTOUzKnDlz7PLLL49rmFy/fr3beFUbqRImAQB1hb5yUVW7aF+nWJ91rUe5qEYrlLJiXYEdddd7tq2w2I3VW0mUrytM0RyDyl/ozPRUm33VEdahRdWX3td1+ionlaW1eIf5kwCAukQrjPWNc5q/5/u1iXXVinqSi2o8UMq0+bk27u8LbPMXsy3v9SmV3rbtaZPcVxJVZvKI3jaqb2LnPwIAACTCtHqQi2olUMp9cxbb5Jf/ZYXrd24CWpGMFntUuunnNUO626WDuiTgGQIAANSM++p4Lqq1QBkk8gkzF1phcUmVVjhpbkB6aopNHNqTyiQAAKgXptXhXFSrgTKYOzB+xgKbu2Rt1KXzwfWaaDppeO8GOWcSAADUXyvqaC6q9UAZunR+6rxcm7NojeXmFVjok9LU044ts21QtzY2pl/HpF/NDQAA0JByUdIEylD52wptWV6+bS8stkbpqda5ZY7leHxFEQAAQF2VXwdyUVIGSgAAANQdDXPTJwAAAMQNgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAAIlAAAAag8VSgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABeCJQAAADwQqAEAACAFwIlAAAAvBAoAQAA4IVACQAAAC8ESgAAAHghUAIAAMALgRIAAABe0v3ujurI31Zoy/LybXthsTVKT7XOLXMsJ5O3AgAA+tW6iRRTQxav3mRT5+XanG/XWO66AisJuS7FzDq2yLZB3dvY6IM7Wte2TWrqaQEAUCfRryaXlJKSktBsgzhbsa7Axs9YYHOXrLW01BQrKq745Q6uH9CllU0a3ts6tMjm/QAAgH416REoE2ja/FybMHOhFRaXVBokywuW6akpdvPQnnZq346JfIoAANQZ9KvJi0CZIPfNWWx/nrXI+zhXD+lmlw3qGpfnBABAXUW/mtxY5Z2gM6h4hEnRcZ6bnxuXYwEAUBfRrzawQDlx4kTbd999rbi4uPSylJQUe+KJJ0r/f9OmTXbttdfakCFDrHXr1u76m266qdzj6bqKfvbZZx9L1jmTGuaOpxtnLrTnZ77pfu8XXnghbsfV+6JjLlu2rMr31X1033fffbdaj/3qq6/a2LFjrXfv3paRkeGOVZ533nnHGjdubCtXrqzW4wBAXRfvvjWUllEcfvjh7vaXXXaZNaR+VcdVH1af+laZPXu29e/f37Kzs61Vq1Z21lln2Zo1ayzRfWvcAuWPP/5ot99+u2v4qakVHzYvL88efvhh27Ztmw0bNqzSY3700UdlfqZMmeKuGz58uCUjLcDRnMl40vEembvU4u344493r+luu+1mNW3GjBn28ccfuz+S++23X4W3O/LII+2ggw6y8ePH1+jzA4BkkIi+NdT9999vS5YssWSWqH5Vx02E42uxb33vvffs2GOPtbZt29rLL79sd999twuY6kvVNhLZt8Zt2yA96ebNm9uIESMqvV2nTp3sl19+cQl87dq19uijj1Z42379+pW57KGHHnL3Pffccy0ZtzDQau5A8Y6tlpqR5X1cLehZsHKDxZvOYvVTGx555JHSP446K/70008rvO2ll15qo0aNsltuucU6dOhQg88SAGpXIvrW0GrYddddZ08++WTU4ydLvxqvvlX9qo57TIvyR8fqat96zTXXWLdu3VzFNT19Z8Tbc8897dBDD7XHH3/cLr744oT1rXGpUG7fvt0ee+wxO/300ys9g5JgyLo6VNKfPn26HXHEEdalS5eYS8d33HGHTZ482Tp37my77LKLDRw40BYtWmQ7duywcePG2e67727NmjVzVc/IsrA899xzrnyck5PjSsRHH320ffbZZ2G3UUm5Z+e2VrR2ua2edoPl3jnSVj97fcy/W+GmtZb3xr32w/1n2fLbh9kP9421n2dMsqL8X9z1qak7XzM95+uvv94956ZNm9pRRx1l3377bdix3n77bTvppJOsffv2lpWV5V6rCy+80P2RiVaW12vTq1cvmz9/vg0YMMCVzPfaay+77bbbwoZbfEVrJ6FOPPFE97orhAJAQ5HovvWCCy6wwYMHV3nEryb71pGnn2G5f/lv275mWdz7Vu2o8vZXq+tN37py5Up3/DPOOKM0TMohhxziQqZGBhPZt8YlUM6bN8+V2wcNGlTu/AyFrXiYNm2a5efn23nnnVel+6mk/+GHH7p/ddb2zTffuBdSVc6ff/7ZpXYNKagsHHnsSZMm2WmnneaGZp9//nl76qmnXLBVg/jqq6/Cblu4Y4f9NH2iZXXqY61H/NGaDxgdc4Nf9b+/t4JFH1nTvsOszSk32a5Hnm8pmTlWvHWzu03xf8r9Kk8vX77c/R4a3li8eLH7XYqKikqP991337kP6YMPPmizZs2yG2+80b1Hhx12mPvQRLNq1SobPXq0jRkzxmbOnOnK5zqLffrpp0tvoz8gem/1IUm0Ro0auQ/Ea6+9lvDHAoBkkci+VX3IJ598Yvfdd1+1j1ETfeuqDVutpKjQ1rz4p7j3rapSfvbD+nrTt3755Zfu3z59+pS5TpcF1yeqb43LkLfmCsgBBxxgiaQzNZX+Tz755CrdT/d56aWXSs/wdDZx5ZVXuoU9mmMQ0IdBczQ3btzozlBWrFhhEyZMcEOy99xzT+ntdEbXtWtXu/nmm90ZluwoKnaNvvmhp1rjPoOr9PzWz51qRQUbbfdz7rWMVr+WnXN6DChz2+779AhrfGlpaXbKKae4s5JgisBFF11Uer0aphqMGqeGRN544w0bOnRopc9Hf8Bef/11N79CdKamCcLPPPOMW0hTG9S2br31VndCobNZAKjvEtW3qpJ19dVXu7Cnilx1Jbpv3byt0P1YceL61tUbtrp/FWzret+al5fn/m3RokWZ63RZcH2i+tbUeE0aVnlXq4kSZeHChe5MQOlepeZQOoMoLCws/YksHx933HFhwwU9evQonTgbKrg8N3fnNj1vvfWWO57e6NDj6/E17B66Ckvfzy3Z3Q+t8u+2demnltWpd1iDr8jBA4eE/X9wJqIzq4CGFtTwNSdCZW+tolaDl6+//jrqY7Rr1660wYc+Tuhj1LQ2bdq491VneADQECSqb1X/oMWQ559/fqW3q+2+dXlefukxEt23RobButy3plQw9aG8y+PZt8alQrllyxb3wirRJ7I6KeUNd++9995hb4jOfEK3S4hM6yrzVnb51q07z1hWr945t6Jv377lPqfQD5JGpFMyMi01s+pfl1hUsMGymsT2B6Nx0+Zh/5+ZmVn6HrjnUVzsto3QH6IbbrjBbcujsw5drrOs4HaVadmyZZnL9Dix3DdRgpOI2nwOAFCTEtG3arHGm2++aR988IFt2LChzJzN9evXuz5Dj1vbfev2wp0Btib61sh+ry72rS3/c/zyKpHr1q0rt3IZz741LoFSZ09qiIkajtSxNb/iwAMPtP3337/M9a+88krYcnifEn6o4KxQH8DgLKQiO9fMVG+xUVp2MyvaFD6ptyLpaZUXlTVH4vPPP3eTgs8888zSy5N9W4ho9GGQRFbBASCZJKJvVR+hamB5u6hocYZ+tHhDWw/Vdt/aKD3o7xLft0ZTF/rWXr16uX8XLFjgqsehdFlwfaL61rgEymCTcU1YLW8yqC9NXtXcDO3DVR6dKSSCVpyprK3fK9q8zcaZ1X8ps/Y60PK/nGM78n6wjJbtK71t6yY7z5oqEpS0g7Or0O2W6rKlS5e6sy/trQUADUEi+lYt5ClvwYcW/ihEXnHFFaXBo7b71s4t/UJ0VfrWaOpC37rHHnu4IXXNBdUc2aCyrT2ftWJd81sT2bfGJVAGjVNPOpZGr8mrOuPSii7Riq5gl3qlai2njxzu1pYE2jqhJmm1lUKsthLQi37MMcfYrrvu6sr1Wh2nM0ZNHg4qh9XcDcmtWNNcj1VTx1mz/iMto3VnK9mWb1uWfmpNDxpmGS1/nf+RlZEW9Q+Qhim0ZYMmDavErbNMbXeQaNoiQftd6ewt9BscyqNhFE12Fv1RkaAN6HX/zW9+E3Z7tS3NranullMAUNckom/V31f9VBRIamLnjlj71pzMdFesKbDE9a1tm2XZzgF4qxd96+TJk93ippEjR9oll1zi5n3qOesk4eyzzy5z+3j2rXEJlJqgqqX+WtWlfa2i0caaofMytLekfuT7778Pa+xaDabl+Vpmr/2sapqW9Gv1lzaXffbZZ135XxNrNfcjdMWXaE8r/WgrgqpIb9LK2o2909Z/MNU2fvyCFW3ZZGnZTS2zfU9LzWoStg9lNJr3okaus0ztj6WzQK0k07YNHTt2tETavHnnFkexfDvAnDlzyjRufQAk8kOjwKlyfSxfIwYA9UUi+9baFmvf2q5ZlpXdwTI+fav66/9q39y+qEd968CBA91Kcm1ppG2PdBJxwgknuD1DI6ur8e5bU0oUtePgxRdfdDuuqzHrLKch0o7+g6e8n7Djz77qcOvSZmfATEYPPPCA+y5ZNdJ4Dk1rArS+yUHHDd2sFQDqu4betzb0frUu9a1x+y5vfW2Tziy0n1FD1bVtExvQpZU764knHU/HTfZGr6rj5ZdfHtcGrxWH2jRXm+ASJgE0NA29b23o/Wpd6lvjVqEMVkFpAY3G66vy1Xr1yYp1BXbUXe/ZtsJiN8/CSqJ8pVKK5l5W/kHJTE+12VcdYR1aVH3bhLpOX8OlIQVNMGb+JICGqKH3raH9qsSjb23I/Wqi+ta4BkrsNG1+ro37+wLb/MVsy3t9SqUvS9vTJrmvk6rM5BG9bVTfxM7RAAAg2ftViUffSr8afwTKBLlvzmKb/PK/rHB95evHMlrsUemGrdcM6W6XDuqSgGcIAEDd6lf/PGuRFW3Z6NW30q8mBoEywWdUE2YutMLikiqt/NbcjvTUFJs4tCeVSQAA6FeTHoGyBuZ+jJ+xwOYuWRt1S6Hgek0UnjS8d4Od2wEAQEXoV5MTgbIGtz6YOi/X5ixaY7l5BRYaKzUdtmPLbBvUrY2N6dexTqw6AwCgNtGvJhcCZS3I31Zoy/Ly3Rff67tK9fVS+kYAAABAv1oXESgBAADgpeFtaAUAAIC4IlACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOAl3e/uAGpD/rZCW5aXb9sLi61Reqp1bpljOZl8nFE30Z6Buo8eCKgjFq/eZFPn5dqcb9dY7roCKwm5LsXMOrbItkHd29jogzta17ZNavGZAtHRnoH6JaWkpCS0XwKQZFasK7DxMxbY3CVrLS01xYqKK/7IBtcP6NLKJg3vbR1aZNfocwWioT0D9ROBEkhi0+bn2oSZC62wuKTSIFlesExPTbGbh/a0U/t2TOhzBGJFewbqLwIlkKTum7PY/jxrkfdxrh7SzS4b1DUuzwmoLtozUL+xyhtI0kpOPMKk6DjPzc+Ny7GA6qA9A/UfgRJ1wsSJE23fffe14uLi0stSUlLsiSeeCLvdJ598YkcffbQ1adLEGjdubIMGDbIPP/zQ6tocMw1z+/rhgXNszfSb3X/fOHOhO64vveY33XRTte47cOBAO+uss6r92GvWrHH3b9WqlWVnZ1v//v3tnXfeCbvNjh07bO+997YpU6ZYXWm3mzZtsmuvvdaGDBlirVu3rvQ1/uCDD+y8886zAw880DIzM91tly1bZg2hPYdSe35+5pvu93/hhRfidly9L9V9TXUf3ffdd9+t1mO/+uqrNnbsWOvdu7dlZGS4Y5VHbV5/21auXFmtxwEShUCJpPfjjz/a7bff7jrn1NSKm+z8+fPt8MMPty1btthTTz3lfrZu3WpHHnmkffTRR1ZXaAGO5kzGk46n4/rS66hAU9O2bdvm3kd1pnfffbe9/PLL1rZtWzvmmGPsvffeK72dOuIbb7zRtZW8vDyrC+1Wz/Phhx92v+OwYcMqPaZ+/9mzZ1vHjh3tkEMOsYbcnh+Zu9Ti7fjjj3dtfLfddrOaNmPGDPv444/dCch+++1X4e30OTjooINs/PjxNfr8gGgIlEh6ChDNmze3ESNGVHq7G264wd3uzTffdB3z8OHDbdasWa5aefXVV1uyU3Xt65W/uNXcVVmAEwsdT8ddsmaT13H69etn7du3t5r22GOP2ZdffmnPP/+8jR492gYPHuwqU926dXPVvVCnnXaaq+489NBDVhfabadOneyXX35xwfjWW2+N2sZVCVP4UPipC1sDhbbn4h1b43JcHW/Byg0Wb6oQq42r+lvTHnnkEVu0aJE999xz7jlU5tJLL7WpU6faihUrauz5AdEQKJHUtm/f7sLE6aefXmmVRzS0rWFVDYcGFCZVtfznP/9pP/30U9TH0/179erlqhSqAO2yyy7WuXNn+9vf/uauf+211+yAAw5wj6GhKYXXSIsXL3bPt02bNq5j6tGjh91///1ht9GwmEKPqqh/+MMfbI899nC3vf/lD9wK7WhKSopt479esR8f/53l/nmE5d41yn568g9WsHhemdtuWfqp/fS3K9zt+h2wnz3++ONh1//88892ySWXuMqIhtL0vH/729/a3Llzyxwrcjg2GCKcM2eOXXzxxW44umXLli5EqUIXLwpQ3bt3d8PcgfT0dBszZoyb5hA6/NeoUSMbNWqUq/rV1q5oVWm3ev0qGt6MFO1YsQ7L3nHHHTZ58mTXttXG1e4VZnRSM27cONt9992tWbNm7qRMUw0iKfTovcjJyXFtRtNMPvvss7DbaHpCz85trWjtcls97QbLvXOkrX72+pifa+GmtZb3xr32w/1n2fLbh9kP9421n2dMsqL8X/7zWux8zfScr7/+evecmzZtakcddZR9++23Ycd6++237aSTTnInQ1lZWdalSxe78MILbe3atVGHvIO/CRoBGTBggPvs77XXXnbbbbeFTWXwVZX39sQTT3Svu0IokCzY2BxJbd68eW5IUHMhI0WGBXXi5VUWgssWLFgQ01DWqlWr7Oyzz3aVL3VA9957r51zzjmuGqCqmIaa1NlqKFOV0KVLl7rOTL766isXRDUk+Ze//MXatWtnb731ll1++eWu85owYULYY1133XWuY/7rX//qOpT/969CKyqO3rHkvXqX5S981xrvN9iaDxhjKWnptn3Vd1a4YXX4a7Lme/vlH49Z037/bWk5za3463fs3HPPdR2qgrasW7fO/avnpue7efNmF+DUkWqIVf9Go2FwVcyeeeYZ9zpdc801Luz94x//KL1NdeeWiaqT6swj9enTx/27cOFCF8oDes4PPvigu5+CfzK329qgExy9dvp3/fr17qRGIeXggw920wZ00rF8+XJX2dd7O3PmzNL7Tpo0yf74xz+6z4j+1edOAVXvj8K9TkwChTt22E/TJ1qT/Y9xbdBKimIOk6v+9/dWUlRozfqfYhltOlvxlk225ft/W/HWzZaWs6sV/6fqqc/joYceao8++qht3LjR/ud//sf9Ll9//bWlpaW523z33Xfuc6bfRZ9dBcY777zTDjvsMPd3Qb9ztL8JqozrddLnRJ8PfXb1ude8R1E4r6n3VidN+jujE1z9HQKSAYESSS2Y+6iqYDTqyDQHSVWD4Gy/sLDQde4S65w63U4hUAsf5De/+Y2r2qkisWTJktLwqH/3339/e/HFF+13v/udu+z3v/+9q4pq8YSqJaLhWc2P0/0VLHfdddfSx9ICkunTp7v/3ryt0C774K2oz2/rii8tf+Eca3rIKNv18DNKL99lr53PN1Txlo3Wbsztlt6sjfv/kg69rMUPC1zwCwKlKn8PPPBA6X2KiopcxUmd7j333BNToNRcRt02oJCqQK6OWCHVl96TFi1alLk8uCzyvQ3ai6rWtREoq9Jua4OG4l966aXSz4lOdq688krbZ5993PzUwDfffOMWOCmoqT3rZEGB6rLLLgt7v9XGu3btajfffLOrXsqOomIXCJsfeqo17jO4Ss9v/dypVlSw0XY/517LaNWh9PKcHmVPKrrv08Oefvrp0v9XiDzllFNcRTEYOr7oootKr1foUxhTu9Z0gzfeeMOGDh1a6fNR+3r99dfd3EVRFVQnSPocBYGypqltaYpEfn6+qxQDtY0hbyQ1DZtqCEpDqdEo1GnYTp2dhkDV+akjUaVFgs5TgVNBM/hRgAqlKmYQJoPQokCp8BiESdFQtgTH1wIgVfQ0TKhhsdDHOO6449z1CryhTj755NL/Xp6XH/Z1ihXRELY0OSD6HLqMNnuWhklJSW9kHTrvXfqcA6qQqoPScKCGklWx0e+iKk8sIjvkoHIY+Tg+KhsWjrxO75fU1krYqrTbRFCbDm1/kUOzao+hQ6xBW46clxlcnpu7c9spnWjpeApRocdXuzniiCPCqtD6fm7J7n5olZ//1qWfWlan3mFhsiIHDxwSte1p2F5/Czp06FDavhUmJZY2rpOiIEyGPk4823dVqY3rfdVJG5AMCJRIalqxrT/+wdBVZTQsrSqg5iVqqFrDzhqCDhbkBEOiGiLSMYMfVQlDlVcJ0xBT5OW6TBQUgyqGOlcNkYceXz/qwCVyzlboEPz2wtjmYxUXbDBLSXXDftGk7bKzShoqvVEj97oGNPSn+Y8a7lS1VaFX1R1VHUNvVxnNmyxvmkGs94/l+OVVmIPh+sj3RgEnno+fyHabCGrToe0vcli0orYcrY2vXr1zSkXfvn3LtHFVJkPbt0akUzIyLTWz6l//WVSwwdKaxBbGGzdtXmnbU+jSlkx///vfXdVcJ0oamg9O7mJpI5HtO3ic2mpfydDGgUgMeSOpqcKjOVqxDuto/pSG7rQwRkPPqkJo8r3uG1QdL7jgAjvhhBNK7xOvFZ0aylaAOOOMM9wqzPLsueeeFVbWGqXHdn6Xmt3MrKTYLU5Ib1w2/EYTWejTcGEw5zCU9kdMFhq21ly3SMFlWjRRXtCsrQphVdttvL3yyitumkUgtLLuI3g9NZc4qPBVZOeamdgWG0VKy25mRZvCT74qkp5W+edG82g///xzt+DmzDPPLL1c01fqstpu40AkAiWSmuZ0BZPqg6GsaBQQg4ChoTpVTs4//3y3mjXoXOPVwYbSMLcWYWi1q55rUN2JVeeWOa77jTbsrbmSGz+abpv//bo1P3xMlR5Dx89KTysTaiND9RdffOHmAWqIMBloGoFWoms+rCqpomqwwrD+P/L91EIpCV0gkuztNp4SNW9Uc2s1ZKzfK3S6RnkaZ1a/e8na60DL/3KO7cj7wTJaVr5NVesmlZ8QBidtkW28treV8qU2rsqp9mMFkgGBEkktWBCi4aloHbMqERqy1SIadR6qSmgIXIsF/vSnP9XY3oNaOaoVrxpG1spPVfpUDVHVKHTVc6SczHTr2CLblkf5RpusDr0sp+cg2/DP56yoYL3tsndfS0nPsO2rl1pKeqY1/c2JFd63Y8tsS4nYlkjVWr0+WmyheXDackVDpKqmKrQl+v3V/ovRVsdqOoNWJI8cOdK9p5o/poVEeq7a6DuS2ouqxcHCo2Rut6KFIapmBlVhTdUIvgFG0yWCrbC0xVOwkXtQndV9tX+ifvT+JZLas9qGtulRoNG0CFXmNRSuYWRVY7UwJ6gcxrgbUhnNB4x28yhXTR1nzfqPtIzWna1kW76bP9z0oGGW0fLXE52sjLSo4V5TALQdktqZhvX1WdRWQommhW36HKkyGvmtXpE0H1NTTUSBXYI2oNddf9dCqW3p/Y51yykg0QiUSGqqkCmcaeWphqoro4qgAptWn2rrG82h1ER8dSQ1Neyoiti///1vF9C0pYoWA2hFrUJtMI+yMoO6t7Gn5i2PurF5yxOuskbtutjmL2bZ5gWzXZBs1KqDNe1/SoX30f6Wg7q1scjNexQOCgoK3L6J+mYX/Q5apKOtUXy2+omF3qdYVoHrBEFz3zQHTouv9Hy1SEphqrwQpRXMer312id7uxWdfIQu8NDK/2D1//fff+8CRbA9kkJ1KFVuJXJRTKJouxy1EZ08Pfvss25oXe+h5lWGrqYO2px+qrpRf3qTVtZu7J22/oOptvHjF6xoyyZLy25qme17WmpWk7B9KKPR/E4FyCuuuMJNf1GFVau0g28cSnT7lli2K9NertqKKVTwXkcGUgVOnVBU92tQgURIKUmGTdGASqjqqI2q1eGG7jVYH+mbRQZPeT9hx5991eHWpc3ODrm2qRqnapG2palozml1qLNVgNeKZG1nU1saUrutSENqz+VRFV0nQWqT8Rya1jcmPfnkk+64CshAMmCVN5KevnVF1Y9oX0tXH3Rt28QGdGkV07flVIWOp+MmU+f7/vvvu6Cl+a3xdMstt7jvO67NMNnQ2m1FGlJ7rqjqqL1n4xkmtRG9pn9og3nCJJIJgRJJT3OE9BVjWngRz686S0aaszjxxB6WZsVWUlxU9qeker9/emqKTRpe8xt8V0Z7HmqOWVUXL0V7/TRfLvKrLmtDQ2q3lVG7U/sTDYiV267D2nhJnWzP5dG0BQW/eNIUCE070Nd6AsmEIW8giUSbYJ/T60hrdcJVVT7u5BG9bVTfxM4XAyoybX6ujfv7Atv8xWzLe31KpS9U29MmWVanyhcy0Z6B5MPkCyCJBKs85fl/5dpTH+/8hpLKNiqP5poh3QmTqFWn9u1oazdvs8n6KtAz76r0thktKp9vSnsGkhMVSiDJKzsTZi60wuKSKq2U1RwzDQtOHNqTMImkQXsG6i8CJZDkVqwrsPEzFtjcJWujbsESXK8FC5pj1qFF1b/2Dkgk2jNQPxEogTq0BcvUebk2Z9Eay80rCPtGnZT/bFqufSbH9OuY9KtfAdozUL8QKIE6KH9boS3Ly7fthcXuO8D1tY36ph2gLqI9A3UfgRIAAABe2IcSAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAAXgiUAAAA8EKgBAAAgBcCJQAAALwQKAEAAOCFQAkAAAAvBEoAAAB4IVACAADAC4ESAAAA5uP/AyiDumJ1xPEOAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualize the topology (optional)\n",
+    "univprim.visualize_topology()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6dd56f9",
+   "metadata": {},
+   "source": [
+    "## 4. Generate Residue Name Mapping\n",
+    "\n",
+    "For PDB/OpenFF export, we need 3-character residue names. The helper function\n",
+    "creates a mapping from full monomer names to PDB-compliant abbreviations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c9cade77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Residue name mapping:\n",
+      "  head            → HEA\n",
+      "  bisphenol_S     → BPS\n",
+      "  bisphenol_A     → BPA\n",
+      "  tail            → TYL\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate residue name mapping for export\n",
+    "# NOTE! These are the 3-character PDB-style residue codes\n",
+    "# You need to set these manually, unless we come up\n",
+    "# with a good way of deriving them automatically.\n",
+    "\n",
+    "resname_mapper = {\n",
+    "    'head' : \"HEA\",\n",
+    "    'bisphenol_S' : \"BPS\",\n",
+    "    'bisphenol_A' : \"BPA\",\n",
+    "    'tail' : \"TYL\"\n",
+    "    }\n",
+    "print(\"Residue name mapping:\")\n",
+    "for name, resname in resname_mapper.items():\n",
+    "    print(f\"  {name:15} → {resname}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a21f9a0",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Export to MDAnalysis\n",
+    "\n",
+    "The MDAnalysis export creates a `Universe` object with proper topology\n",
+    "(atoms, residues, segments/chains, bonds). This is useful for trajectory\n",
+    "analysis and visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "779b0fcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing inter-residue bonds...\n",
+      "Added 123 inter-residue bonds\n",
+      "Total bonds: 3874\n",
+      "Bond orders collected: 3874\n",
+      "Atoms: 3618, Residues: 133, Segments: 10\n",
+      "Unique atom_resindex: [  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17\n",
+      "  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35\n",
+      "  36  37  38  39  40  41  42  43  44  45  46  47  48  49  50  51  52  53\n",
+      "  54  55  56  57  58  59  60  61  62  63  64  65  66  67  68  69  70  71\n",
+      "  72  73  74  75  76  77  78  79  80  81  82  83  84  85  86  87  88  89\n",
+      "  90  91  92  93  94  95  96  97  98  99 100 101 102 103 104 105 106 107\n",
+      " 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125\n",
+      " 126 127 128 129 130 131 132]\n",
+      "Unique atom_segindex: [0 1 2 3 4 5 6 7 8 9]\n",
+      "Total bonds collected: 3874\n",
+      "Total bond orders collected: 3874\n",
+      "Adding 3874 bonds to universe\n",
+      "Added 3874 bonds with 3874 bond orders\n",
+      "Bond order distribution: {1.0: 1584, 1.5: 2290}\n",
+      "MDAnalysis Universe:\n",
+      "  Atoms: 3618\n",
+      "  Residues: 133\n",
+      "  Segments (chains): 10\n",
+      "  Bonds: 3874\n"
+     ]
+    }
+   ],
+   "source": [
+    "import MDAnalysis as mda\n",
+    "\n",
+    "# Export to MDAnalysis Universe\n",
+    "mda_universe = primitive_to_mdanalysis(univprim, resname_map=resname_mapper)\n",
+    "\n",
+    "print(f\"MDAnalysis Universe:\")\n",
+    "print(f\"  Atoms: {len(mda_universe.atoms)}\")\n",
+    "print(f\"  Residues: {len(mda_universe.residues)}\")\n",
+    "print(f\"  Segments (chains): {len(mda_universe.segments)}\")\n",
+    "print(f\"  Bonds: {len(mda_universe.bonds)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "40ae7d81",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Atoms in bisphenol_S residues: 1128\n",
+      "\n",
+      "Chain summary:\n",
+      "  Chain 1: 11 residues, 297 atoms\n",
+      "  Chain 2: 8 residues, 213 atoms\n",
+      "  Chain 3: 17 residues, 477 atoms\n",
+      "  Chain 4: 19 residues, 513 atoms\n",
+      "  Chain 5: 15 residues, 405 atoms\n",
+      "  Chain 6: 12 residues, 327 atoms\n",
+      "  Chain 7: 17 residues, 471 atoms\n",
+      "  Chain 8: 9 residues, 255 atoms\n",
+      "  Chain 9: 11 residues, 303 atoms\n",
+      "  Chain 10: 14 residues, 357 atoms\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example: Select by residue name\n",
+    "BPS_atoms = mda_universe.select_atoms(\"resname BPS\")\n",
+    "print(f\"\\nAtoms in bisphenol_S residues: {len(BPS_atoms)}\")\n",
+    "\n",
+    "# Example: Iterate over chains\n",
+    "print(\"\\nChain summary:\")\n",
+    "for seg in mda_universe.segments:\n",
+    "    print(f\"  Chain {seg.segid}: {len(seg.residues)} residues, {len(seg.atoms)} atoms\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9922761",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6. Export to RDKit (Hierarchical)\n",
+    "\n",
+    "The RDKit hierarchical export preserves:\n",
+    "- **Bond orders** from connector bondtypes\n",
+    "- **AtomPDBResidueInfo** for chain/residue metadata\n",
+    "- **3D coordinates** from the Primitive shapes\n",
+    "\n",
+    "This is the basis for OpenFF conversion and can also be used for\n",
+    "direct PDB/SDF file export."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "d4a3a209",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added 150522 atoms to RDKit molecule\n",
+      "Added 155991 intra-residue bonds\n",
+      "Added 5369 inter-residue bonds\n",
+      "\n",
+      "RDKit Molecule:\n",
+      "  Atoms: 150522\n",
+      "  Bonds: 161360\n",
+      "  Bond types: {'AROMATIC': 65628, 'SINGLE': 91116, 'DOUBLE': 4616}\n",
+      "  Radical electrons: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "# Export to RDKit with hierarchy preservation\n",
+    "rdkit_mol = primitive_to_rdkit_hierarchical(univprim, resname_map=resname_mapper)\n",
+    "\n",
+    "print(f\"\\nRDKit Molecule:\")\n",
+    "print(f\"  Atoms: {rdkit_mol.GetNumAtoms()}\")\n",
+    "print(f\"  Bonds: {rdkit_mol.GetNumBonds()}\")\n",
+    "\n",
+    "# Check bond type distribution\n",
+    "bond_types = Counter(bond.GetBondType().name for bond in rdkit_mol.GetBonds())\n",
+    "print(f\"  Bond types: {dict(bond_types)}\")\n",
+    "\n",
+    "# Check for radicals (should be 0 for valid molecules)\n",
+    "radicals = sum(atom.GetNumRadicalElectrons() for atom in rdkit_mol.GetAtoms())\n",
+    "print(f\"  Radical electrons: {radicals}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f3a693c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display RDKit molecule (2D depiction)\n",
+    "display(rdkit_mol)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f56d144c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7. Export to OpenFF\n",
+    "\n",
+    "OpenFF (Open Force Field) provides modern force field parameterization.\n",
+    "The export creates OpenFF `Molecule` objects that preserve all hierarchy\n",
+    "metadata and can be parameterized with SMIRNOFF force fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "faba48ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added 3618 atoms to RDKit molecule\n",
+      "Added 3751 intra-residue bonds\n",
+      "Added 123 inter-residue bonds\n",
+      "\n",
+      "OpenFF Export: 10 molecules\n",
+      "  Chain 1: 297 atoms, 11 residues\n",
+      "  Chain 2: 213 atoms, 8 residues\n",
+      "  Chain 3: 477 atoms, 17 residues\n",
+      "  Chain 4: 513 atoms, 19 residues\n",
+      "  Chain 5: 405 atoms, 15 residues\n",
+      "  Chain 6: 327 atoms, 12 residues\n",
+      "  Chain 7: 471 atoms, 17 residues\n",
+      "  Chain 8: 255 atoms, 9 residues\n",
+      "  Chain 9: 303 atoms, 11 residues\n",
+      "  Chain 10: 357 atoms, 14 residues\n"
+     ]
+    }
+   ],
+   "source": [
+    "from openff.toolkit import Molecule as OFFMolecule, Topology as OFFTopology\n",
+    "\n",
+    "# Export to OpenFF Molecules (one per chain)\n",
+    "offmols = primitive_to_openff_molecules(univprim, resname_map=resname_mapper)\n",
+    "\n",
+    "print(f\"\\nOpenFF Export: {len(offmols)} molecules\")\n",
+    "for i, mol in enumerate(offmols):\n",
+    "    n_residues = len(list(mol.residues))\n",
+    "    print(f\"  Chain {i+1}: {mol.n_atoms} atoms, {n_residues} residues\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0b0d4b11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Metadata on first atom of first chain:\n",
+      "  residue_name: HEA\n",
+      "  residue_number: 1\n",
+      "  chain_id: A\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verify metadata preservation\n",
+    "test_mol = offmols[0]\n",
+    "test_atom = list(test_mol.atoms)[0]\n",
+    "\n",
+    "print(\"\\nMetadata on first atom of first chain:\")\n",
+    "print(f\"  residue_name: {test_atom.metadata.get('residue_name', 'N/A')}\")\n",
+    "print(f\"  residue_number: {test_atom.metadata.get('residue_number', 'N/A')}\")\n",
+    "print(f\"  chain_id: {test_atom.metadata.get('chain_id', 'N/A')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7a11f61",
+   "metadata": {},
+   "source": [
+    "### 7.1 Save and Reload OpenFF System\n",
+    "\n",
+    "The serialization utilities allow saving and loading the complete system\n",
+    "with all metadata preserved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1404dfe8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Saved files:\n",
+      "  json: mupt-built_systems/copolymer_10x[5-20]mer.json\n",
+      "  sdf: mupt-built_systems/copolymer_10x[5-20]mer.sdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save the system\n",
+    "output_dir = Path('mupt-built_systems')\n",
+    "output_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "system_name = f'copolymer_{n_chains}x[{chain_len_min}-{chain_len_max}]mer'\n",
+    "saved_files = save_openff_system(offmols, output_dir / system_name)\n",
+    "\n",
+    "print(f\"\\nSaved files:\")\n",
+    "for fmt, path in saved_files.items():\n",
+    "    print(f\"  {fmt}: {path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4b8deff1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Reloaded 10 molecules\n",
+      "  Chain 1: 297 atoms, 11 residues\n",
+      "  Chain 2: 213 atoms, 8 residues\n",
+      "  Chain 3: 477 atoms, 17 residues\n",
+      "  Chain 4: 513 atoms, 19 residues\n",
+      "  Chain 5: 405 atoms, 15 residues\n",
+      "  Chain 6: 327 atoms, 12 residues\n",
+      "  Chain 7: 471 atoms, 17 residues\n",
+      "  Chain 8: 255 atoms, 9 residues\n",
+      "  Chain 9: 303 atoms, 11 residues\n",
+      "  Chain 10: 357 atoms, 14 residues\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reload and verify\n",
+    "loaded_mols = load_openff_system(saved_files['json'])\n",
+    "\n",
+    "print(f\"\\nReloaded {len(loaded_mols)} molecules\")\n",
+    "for i, mol in enumerate(loaded_mols):\n",
+    "    n_residues = len(list(mol.residues))\n",
+    "    print(f\"  Chain {i+1}: {mol.n_atoms} atoms, {n_residues} residues\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea017f95",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated the complete MuPT workflow:\n",
+    "\n",
+    "1. **Build**: Defined polymer chemistry with SMILES and built a random copolymer system\n",
+    "2. **Export**: \n",
+    "   - **MDAnalysis**: For trajectory analysis and visualization\n",
+    "   - **RDKit**: For chemical manipulation and 2D/3D structure handling\n",
+    "   - **OpenFF**: For force field parameterization\n",
+    "3. **Simulate**: Ran energy minimization and short MD with OpenMM\n",
+    "\n",
+    "### Key Functions\n",
+    "\n",
+    "| Function | Purpose |\n",
+    "|----------|--------|\n",
+    "| `build_copolymer_system()` | Build polymer system from SMILES |\n",
+    "| `primitive_to_mdanalysis()` | Export to MDAnalysis Universe |\n",
+    "| `primitive_to_rdkit_hierarchical()` | Export to RDKit with hierarchy |\n",
+    "| `primitive_to_openff_molecules()` | Export to OpenFF Molecules |\n",
+    "| `save_openff_system()` / `load_openff_system()` | Serialize/deserialize systems |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c560271",
+   "metadata": {},
+   "source": [
+    "## 8. OpenMM Simulation (NPT Ensemble)\n",
+    "\n",
+    "Now we'll run a molecular dynamics simulation using OpenMM. This section follows the optimized workflow from `mdfiles_with_openff.ipynb`:\n",
+    "\n",
+    "**Key optimizations:**\n",
+    "1. **Per-molecule parameterization**: Parameterize each molecule individually, then combine with `Interchange.combine()`. This is significantly faster than parameterizing the whole topology at once.\n",
+    "2. **Automatic Partial Charge Assignment**:  We use `openff-gnn-am1bcc-1.0.0.pt`\n",
+    "3. **NPT ensemble**: Langevin integrator with Monte Carlo barostat for constant temperature and pressure\n",
+    "4. **System serialization**: Save topology, system, state, and integrator to files for reproducibility\n",
+    "5. **Reporters**: DCD trajectory and state data reporters for analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9d1724c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "offdir : Path = Path('OpenFF_MD_input_files')\n",
+    "offdir.mkdir(exist_ok=True)\n",
+    "system_name : str = 'amorphous_melt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e1feb409",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e62f7189f6941adaa6cade81a2f3737",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/openff/interchange/operations/_combine.py:104: InterchangeCombinationWarning: Interchange object combination is complex and may produce strange results outside of use cases it has been tested in. Use with caution and thoroughly validate results!\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combined interchange with 3618 atoms\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parameterize each molecule individually, then combine (much faster than parameterizing topology)\n",
+    "from functools import reduce\n",
+    "from rich.progress import track\n",
+    "from openff.toolkit import ForceField\n",
+    "from openff.interchange import Interchange\n",
+    "from openff.units import unit as off_unit\n",
+    "\n",
+    "ff = ForceField('openff-2.2.1.offxml')\n",
+    "\n",
+    "# Assign partial charges and parameterize each molecule\n",
+    "mol_interchanges = []\n",
+    "for offmol in track(offmols, description='Parameterizing molecules'):\n",
+    "    # Use gasteiger for speed (use 'openff-gnn-am1bcc-1.0.0.pt' for production)\n",
+    "    offmol.assign_partial_charges(partial_charge_method='openff-gnn-am1bcc-1.0.0.pt') #  partial_charge_method='gasteiger'\n",
+    "    mol_inc = ff.create_interchange(\n",
+    "        offmol.to_topology(), \n",
+    "        charge_from_molecules=[offmol]\n",
+    "    )\n",
+    "    mol_interchanges.append(mol_inc)\n",
+    "\n",
+    "# Combine all molecule interchanges into one\n",
+    "# NOTE: I tested this with 100 5-10-mers ~150k atoms total and it took more\n",
+    "# than 20 minutes to do this last step before crashing. This may have been fixed in the\n",
+    "# latest version of OpenFF\n",
+    "interchange = reduce(Interchange.combine, mol_interchanges)\n",
+    "print(f\"Combined interchange with {interchange.topology.n_atoms} atoms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "678e197c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Box dimensions: 24.79 x 17.92 x 21.48 nm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set up simulation box with padding\n",
+    "positions = interchange.positions\n",
+    "bbox_dims = np.ptp(positions, axis=0)  # Bounding box dimensions\n",
+    "\n",
+    "# Add padding around the system\n",
+    "padding = 1.0 * off_unit.nanometer\n",
+    "box_lengths = (bbox_dims + 2 * padding).m_as(off_unit.nanometer)\n",
+    "interchange.box = np.diag(box_lengths) * off_unit.nanometer\n",
+    "\n",
+    "print(f\"Box dimensions: {box_lengths[0]:.2f} x {box_lengths[1]:.2f} x {box_lengths[2]:.2f} nm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "5181c985",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulation parameters\n",
+    "from openmm.unit import Quantity, kelvin, picosecond, femtosecond, nanosecond, atmosphere\n",
+    "\n",
+    "# Simulation parameters\n",
+    "temperature : Quantity = 300.0 * kelvin\n",
+    "pressure : Quantity = 1.0 * atmosphere\n",
+    "\n",
+    "\n",
+    "sim_time_total : Quantity = 0.5*nanosecond\n",
+    "time_step : Quantity = 2.0*femtosecond\n",
+    "n_samples : int = 100\n",
+    "\n",
+    "friction : Quantity = 1.0 / picosecond\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "d0429861",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created NPT simulation at 300.0 K and 1.0 atm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Integrator and Barostat Parameters\n",
+    "\n",
+    "from openmm import LangevinMiddleIntegrator, MonteCarloBarostat\n",
+    "\n",
+    "n_steps : int = round(sim_time_total / time_step)\n",
+    "\n",
+    "# Create integrator and barostat\n",
+    "integrator = LangevinMiddleIntegrator(temperature, friction, time_step)\n",
+    "barostat = MonteCarloBarostat(pressure, temperature, 25)  # Update every 25 steps\n",
+    "\n",
+    "# Create OpenMM simulation with barostat\n",
+    "simulation = interchange.to_openmm_simulation(\n",
+    "    integrator=integrator,\n",
+    "    combine_nonbonded_forces=False,  # Required for proper PME handling\n",
+    "    additional_forces=[barostat],\n",
+    ")\n",
+    "\n",
+    "print(f\"Created NPT simulation at {temperature} and {pressure}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d2c296b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:885: UserWarning: Unit cell dimensions not found. CRYST1 record set to unitary values.\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'altLocs' Using default value of ' '\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'icodes' Using default value of ' '\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'chainIDs' Using default value of ''\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'occupancies' Using default value of '1.0'\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'tempfactors' Using default value of '0.0'\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'record_types' Using default value of 'ATOM'\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1282: UserWarning: Found no information for attr: 'formalcharges' Using default value of '0'\n",
+      "  warnings.warn(\n",
+      "/home/joelaforet/miniconda3/envs/mupt-env/lib/python3.13/site-packages/MDAnalysis/coordinates/PDB.py:1336: UserWarning: Found missing chainIDs. Corresponding atoms will use value of 'X'\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "ag = mda_universe.select_atoms('all')\n",
+    "ag.write(\"test_copolymer_structure.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "50e60db1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running energy minimization...\n",
+      "Minimized potential energy: -1619.606572029792 kJ/mol\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Minimize energy\n",
+    "print(\"Running energy minimization...\")\n",
+    "simulation.minimizeEnergy()\n",
+    "\n",
+    "# Get minimized state\n",
+    "state = simulation.context.getState(getEnergy=True, getPositions=True)\n",
+    "print(f\"Minimized potential energy: {state.getPotentialEnergy()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "226e5966",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openmm import XmlSerializer\n",
+    "from openmm.app import PDBFile\n",
+    "\n",
+    "\n",
+    "ommdir = offdir / 'OpenMM'\n",
+    "ommdir.mkdir(exist_ok=True)\n",
+    "\n",
+    "# topology\n",
+    "top_path : Path = ommdir / f'{system_name}_topology.pdb'\n",
+    "with top_path.open('w') as top_file:\n",
+    "    PDBFile.writeFile(simulation.topology, state.getPositions(asNumpy=True), top_file)\n",
+    "    \n",
+    "# system\n",
+    "sys_path : Path = ommdir / f'{system_name}_system.xml'\n",
+    "with sys_path.open('w') as sys_file:\n",
+    "    sys_file.write(XmlSerializer.serialize(simulation.system))\n",
+    "    \n",
+    "# state\n",
+    "state_path : Path = ommdir / f'{system_name}_state.xml'\n",
+    "with state_path.open('w') as state_file:\n",
+    "    state_file.write(XmlSerializer.serialize(state))\n",
+    "    \n",
+    "# integrator\n",
+    "integ_path : Path = ommdir / f'{system_name}_integrator.xml'\n",
+    "with integ_path.open('w') as int_file:\n",
+    "    int_file.write(XmlSerializer.serialize(integrator))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "9c7923ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running 250000 steps of NPT dynamics...\n",
+      "\n",
+      "Trajectory saved to: OpenFF_MD_input_files/OpenMM/amorphous_melt_trajectory.dcd\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set up reporters for trajectory and thermodynamic data\n",
+    "from openmm.app import DCDReporter, StateDataReporter\n",
+    "import sys\n",
+    "\n",
+    "# Trajectory output\n",
+    "report_interval : int = round(n_steps / n_samples)\n",
+    "\n",
+    "dcd_path = ommdir / f'{system_name}_trajectory.dcd'\n",
+    "simulation.reporters.append(DCDReporter(str(dcd_path), report_interval))\n",
+    "\n",
+    "state_data_path : Path = ommdir / f'{system_name}_state_data.csv'\n",
+    "state_params : dict[str, bool] = {\n",
+    "    'step' : False,\n",
+    "    'time' : True,\n",
+    "    'potentialEnergy' : True,\n",
+    "    'kineticEnergy' : True,\n",
+    "    'totalEnergy' : False,\n",
+    "    'temperature' : True,\n",
+    "    'volume' : True,\n",
+    "    'density' : True,\n",
+    "    'progress' : False,\n",
+    "    'remainingTime' : False,\n",
+    "    'speed' : True,\n",
+    "    'elapsedTime' : False,\n",
+    "}\n",
+    "statedata_reporter = StateDataReporter(\n",
+    "    str(state_data_path),\n",
+    "    reportInterval=report_interval,\n",
+    "    **state_params\n",
+    ")\n",
+    "simulation.reporters.append(statedata_reporter)\n",
+    "\n",
+    "print(f\"Running {n_steps} steps of NPT dynamics...\")\n",
+    "simulation.step(n_steps)\n",
+    "print(f\"\\nTrajectory saved to: {dcd_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "70527d01",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully reloaded serialized OpenMM components!\n",
+      "  System: 3618 particles\n",
+      "  State energy: -1619.606572029792 kJ/mol\n",
+      "\n",
+      "All MD files saved to: OpenFF_MD_input_files/OpenMM\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verify saved files can be reloaded\n",
+    "from openmm.app import PDBFile\n",
+    "from openmm import XmlSerializer\n",
+    "\n",
+    "# Reload system\n",
+    "with open(sys_path, 'r') as f:\n",
+    "    reloaded_system = XmlSerializer.deserialize(f.read())\n",
+    "\n",
+    "# Reload state\n",
+    "with open(state_path, 'r') as f:\n",
+    "    reloaded_state = XmlSerializer.deserialize(f.read())\n",
+    "\n",
+    "print(\"Successfully reloaded serialized OpenMM components!\")\n",
+    "print(f\"  System: {reloaded_system.getNumParticles()} particles\")\n",
+    "print(f\"  State energy: {reloaded_state.getPotentialEnergy()}\")\n",
+    "print(f\"\\nAll MD files saved to: {ommdir}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ce6038",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mupt-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

This PR adds a tutorial notebook demonstrating the hierarchical export pipeline implemented in MuPT-hub/mupt#22.

The notebook ([Random_CoPolymer_Quickstart.ipynb](https://github.com/MuPT-hub/mupt-examples/blob/MDAexport/examples_system/Random_CoPolymer_Quickstart.ipynb)) provides a complete end-to-end workflow:

1. **Build** – Define polymer chemistry via SMILES and construct a random copolymer system using `build_copolymer_system()`
2. **Export** – Demonstrate the three-layer export pipeline:
   - `primitive_to_rdkit_hierarchical()` → RDKit with `AtomPDBResidueInfo`
   - `primitive_to_openff_molecules()` → OpenFF with hierarchy schemes
   - `primitive_to_mdanalysis()` → MDAnalysis Universe with topology attributes
3. **Serialize** – Save/load systems using `save_openff_system()` / `load_openff_system()`
4. **Simulate** – Run NPT molecular dynamics with OpenMM via OpenFF Interchange

## Related PRs

- **Depends on:** MuPT-hub/mupt#22 (hierarchical export pipeline implementation)

## Notes

- Requires the `release-env` conda environment with OpenMM GPU support for the MD simulation section
- The notebook validates that chain/residue metadata is preserved through each export layer

## Status
- [x] Ready for review