### PR TITLE
Restore runnability of OpenFF-based examples

### DIFF
--- a/examples_system/mdfiles_with_openff.ipynb
+++ b/examples_system/mdfiles_with_openff.ipynb
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "4d82ad2c",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
## Description
Fix test failures described in #16 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Tweak [mdfiles_with_openff.ipynb](https://github.com/MuPT-hub/mupt-examples/blob/main/examples_system/mdfiles_with_openff.ipynb) to run to completion
    - [x] Verify notebook tests pass with reinstalled env
    - [x] Ensure changes are backwards-compatible (run in environment installed c. early Dec 2025)

## Status
- [x] Verify all [nbval notebook tests](https://github.com/MuPT-hub/mupt-examples/blob/main/notebook_tests_master.sh) all pass