### PR TITLE
fix(env): pin OpenFF example dependencies

### DIFF
--- a/conda-envs/release-env.yml
+++ b/conda-envs/release-env.yml
@@ -4,8 +4,7 @@ channels:
   - defaults
 dependencies:
     # Basic Python dependencies
-    # - python>=3.12
-    - python
+    - python=3.13
     - pip
     - jupyterlab
 
@@ -36,8 +35,10 @@ dependencies:
 
     # Molecular Dynamics toolkits
     ## OpenFF
-    - openff-toolkit
-    - openff-interchange
+    - openff-toolkit=0.18.0
+    - openff-interchange=0.5.2
+    - openff-units=0.3.2
+    - pydantic=2.11.10
 
     ## HOOMD
     - hoomd


### PR DESCRIPTION
## Summary

Tests involving the `mdfiles_with_openff.ipynb` notebook were failing CI on the main MuPT repository. Per the comments on https://github.com/MuPT-hub/mupt/pull/86 , I got things to work by pinning the OpenFF/Pydantic versions in the examples release environment.


## Verification
- `mamba env create --dry-run -f conda-envs/release-env.yml`
- `mamba run -n mupt-env python` import check for the failing OpenFF notebook imports

## Note
Pixi lock files should prevent this class of drifting-environment failure in the future. For now, this quick pin should unblock PRs on the main repo.